### PR TITLE
fixed the default title display

### DIFF
--- a/lib/src/header/timetable_header.dart
+++ b/lib/src/header/timetable_header.dart
@@ -60,7 +60,7 @@ class TimetableHeader<E extends Event> extends StatelessWidget {
                       context.timetableTheme?.totalDateIndicatorHeight ?? 72,
                   child: MultiDateHeader(
                     controller: controller,
-                    builder: dateHeaderBuilder ?? (_, __) => Container(),
+                    builder: dateHeaderBuilder,
                   ),
                 ),
                 AllDayEvents<E>(


### PR DESCRIPTION
Fixed the default title display:
MultiDateHeader has return builder?.call(context, date) ?? Center(child: DateHeader(date));

Hello I use your fork, hopefully this fix help other